### PR TITLE
Bump clang-sys version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ keywords = ["C","expression","parser"]
 nom = "^1"
 
 [dev-dependencies]
-clang-sys = "0.7.0"
+clang-sys = "0.11.0"


### PR DESCRIPTION
I had to make breaking changes in `clang-sys` to avoid undefined behavior (KyleMayes/clang-sys#42) that led to crashes with `libclang` 3.9. All of the enums have been changed to constants.

This pull requests updates your crate to be compatible with the latest version of `clang-sys`.