### PR TITLE
update to nom 4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cexpr"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["Jethro Beekman <jethro@jbeekman.nl>"]
 license = "Apache-2.0/MIT"
 description = "A C expression parser and evaluator"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/jethrogb/rust-cexpr"
 keywords = ["C","expression","parser"]
 
 [dependencies]
-nom = {version = "^3", features = ["verbose-errors"] }
+nom = {version = "^4", features = ["verbose-errors"] }
 
 [dev-dependencies]
 clang-sys = "0.11.0"

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -35,7 +35,7 @@ pub struct IdentifierParser<'ident> {
 #[derive(Copy,Clone)]
 struct PRef<'a>(&'a IdentifierParser<'a>);
 
-pub type CResult<'a,R:'a> = IResult<&'a [Token],R,::Error>;
+pub type CResult<'a,R> = IResult<&'a [Token],R,::Error>;
 
 /// The result of parsing a literal or evaluating an expression.
 #[derive(Debug,Clone,PartialEq)]
@@ -163,11 +163,11 @@ macro_rules! comp (
 				rest => rest
 			}
 		}
-		);
+	);
 	($i:expr, $f:expr) => (
 		comp!($i, call!($f));
-		);
 	);
+);
 
 // ==================================================
 // ============= Numeric expressions ================
@@ -519,7 +519,7 @@ impl<'ident> IdentifierParser<'ident> {
 	/// identifier, and the macro otherwise parses as an expression, it will
 	/// return a result even on function-like macros.
 	///
-	/// ```ignore
+	/// ```c
 	/// // will evaluate into IDENTIFIER
 	/// #define DELETE(IDENTIFIER)
 	/// // will evaluate into IDENTIFIER-3

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,18 +39,25 @@ pub enum Error {
     Partial,
 }
 
+impl From<u32> for Error {
+  fn from(_: u32) -> Self {
+    Error::InvalidLiteral
+  }
+}
+
 macro_rules! identity (
     ($i:expr,$e:expr) => ($e);
 );
 
 /// If the input result indicates a succesful parse, but there is data left,
 /// return an `Error::Partial` instead.
-pub fn assert_full_parse<I,O,E>(result: IResult<&[I],O,E>) -> IResult<&[I],O,::Error> {
+pub fn assert_full_parse<I,O,E>(result: IResult<&[I],O,E>) -> IResult<&[I],O,::Error>
+  where Error: From<E> {
 	match fix_error!((),::Error,identity!(result)) {
-		IResult::Done(rem,output) => if rem.len()==0 {
-			IResult::Done(rem, output)
+		Ok((rem,output)) => if rem.len()==0 {
+			Ok((rem, output))
 		} else {
-			IResult::Error(Err::Position(ErrorKind::Custom(::Error::Partial), rem))
+			Err(Err::Error(error_position!(rem, ErrorKind::Custom(::Error::Partial))))
 		},
 		r => r,
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,9 +40,9 @@ pub enum Error {
 }
 
 impl From<u32> for Error {
-  fn from(_: u32) -> Self {
-    Error::InvalidLiteral
-  }
+	fn from(_: u32) -> Self {
+		Error::InvalidLiteral
+	}
 }
 
 macro_rules! identity (

--- a/src/literal.rs
+++ b/src/literal.rs
@@ -85,22 +85,19 @@ macro_rules! full (
 	($i: expr, $submac:ident!( $($args:tt)* )) => (
 		{
 			use ::nom_crate::lib::std::result::Result::*;
-      let res =  $submac!($i, $($args)*);
-      match res {
-        Ok((i, o)) => {
-          if i.len() == 0 {
-            Ok((i, o))
-          } else {
-            Err(::nom_crate::Err::Error(error_position!(i, ::nom_crate::ErrorKind::Custom(42))))
-          }
-        },
-        r => r,
-      }
-    }
+			let res =  $submac!($i, $($args)*);
+			match res {
+				Ok((i, o)) => if i.len() == 0 {
+					Ok((i, o))
+				} else {
+					Err(::nom_crate::Err::Error(error_position!(i, ::nom_crate::ErrorKind::Custom(42))))
+				},
+				r => r,
+			}
+		}
 	);
-
-($i:expr, $f:ident) => (
-	full!($i, call!($f));
+	($i:expr, $f:ident) => (
+		full!($i, call!($f));
 	);
 );
 
@@ -194,17 +191,6 @@ named!(c_char<CChar>,
 	)
 );
 
-fn not_double_quotes(input: &[u8]) -> IResult<&[u8], &[u8]> {
-	use ::nom_crate::InputTakeAtPosition;
-	use std::str::from_utf8;
-
-	let r = input.split_at_position(|c| c == b'"');
-	match r {
-		Err(Err::Incomplete(_)) => Ok((&input[input.len()..], input)),
-		res => res,
-	}
-}
-
 named!(c_string<Vec<u8> >,
 	delimited!(
 		alt!( preceded!(c_width_prefix,char!('"')) | char!('"') ),
@@ -228,7 +214,6 @@ fn c_int_radix(n: Vec<u8>, radix: u32) -> Option<u64> {
 
 fn take_ul(input: &[u8]) -> IResult<&[u8], &[u8]> {
 	use ::nom_crate::InputTakeAtPosition;
-	use std::str::from_utf8;
 
 	let r = input.split_at_position(|c| c != b'u' && c != b'U' && c != b'l' && c != b'L');
 	match r {

--- a/src/literal.rs
+++ b/src/literal.rs
@@ -84,7 +84,7 @@ impl Into<Vec<u8>> for CChar {
 // ====================================================
 
 macro_rules! force_type (
-	($input:expr,IResult<$i:ty,$o:ty,$e:ty>) => (IResult::Error::<$i,$o,$e>(Err::Position(ErrorKind::Fix,$input)))
+	($input:expr,IResult<$i:ty,$o:ty,$e:ty>) => (Err::<($i,$o),Err<$i,$e>>(::nom_crate::Err::Error(error_position!($input, ErrorKind::Fix))))
 );
 
 
@@ -95,9 +95,9 @@ macro_rules! force_type (
 macro_rules! byte (
 	($i:expr, $($p: pat)|* ) => ({
 		match $i.split_first() {
-			$(Some((&c @ $p,rest)))|* => IResult::Done::<&[_],u8,u32>(rest,c),
-			Some(_) => IResult::Error(Err::Position(ErrorKind::OneOf,$i)),
-			None => IResult::Incomplete(Needed::Size(1)),
+			$(Some((&c @ $p,rest)))|* => Ok::<(&[_],u8),::nom_crate::Err<&[_],u32>>((rest,c)),
+			Some(_) => Err(::nom_crate::Err::Error(error_position!($i, ErrorKind::OneOf))),
+			None => Err(::nom_crate::Err::Incomplete(Needed::Size(1))),
 		}
 	})
 );

--- a/src/literal.rs
+++ b/src/literal.rs
@@ -79,6 +79,31 @@ impl Into<Vec<u8>> for CChar {
 	}
 }
 
+/// ensures the child parser consumes the whole input
+#[macro_export]
+macro_rules! full (
+	($i: expr, $submac:ident!( $($args:tt)* )) => (
+		{
+			use ::nom_crate::lib::std::result::Result::*;
+      let res =  $submac!($i, $($args)*);
+      match res {
+        Ok((i, o)) => {
+          if i.len() == 0 {
+            Ok((i, o))
+          } else {
+            Err(::nom_crate::Err::Error(error_position!(i, ::nom_crate::ErrorKind::Custom(42))))
+          }
+        },
+        r => r,
+      }
+    }
+	);
+
+($i:expr, $f:ident) => (
+	full!($i, call!($f));
+	);
+);
+
 // ====================================================
 // ======== macros that shouldn't be necessary ========
 // ====================================================
@@ -142,7 +167,7 @@ fn c_unicode_escape(n: Vec<u8>) -> Option<CChar> {
 }
 
 named!(escaped_char<CChar>,
-	preceded!(char!('\\'),alt!(
+	preceded!(complete!(char!('\\')),alt_complete!(
 		map!(one_of!(r#"'"?\"#),CChar::Char) |
 		map!(one_of!("abfnrtv"),escape2char) |
 		map_opt!(many_m_n!(1,3,octal),|v|c_raw_escape(v,8)) |
@@ -169,11 +194,22 @@ named!(c_char<CChar>,
 	)
 );
 
+fn not_double_quotes(input: &[u8]) -> IResult<&[u8], &[u8]> {
+	use ::nom_crate::InputTakeAtPosition;
+	use std::str::from_utf8;
+
+	let r = input.split_at_position(|c| c == b'"');
+	match r {
+		Err(Err::Incomplete(_)) => Ok((&input[input.len()..], input)),
+		res => res,
+	}
+}
+
 named!(c_string<Vec<u8> >,
 	delimited!(
 		alt!( preceded!(c_width_prefix,char!('"')) | char!('"') ),
 		fold_many0!(
-			alt!(map!(escaped_char, |c:CChar| c.into()) | map!(is_not!("\""), |c: &[u8]| c.into())),
+			alt!(map!(escaped_char, |c:CChar| c.into()) | map!(complete!(is_not!("\"")), |c: &[u8]| c.into())),
 			Vec::new(),
 			|mut v: Vec<u8>, res:Vec<u8>| { v.extend_from_slice(&res); v }
 		),
@@ -190,14 +226,25 @@ fn c_int_radix(n: Vec<u8>, radix: u32) -> Option<u64> {
 		.and_then(|i|u64::from_str_radix(i,radix).ok())
 }
 
+fn take_ul(input: &[u8]) -> IResult<&[u8], &[u8]> {
+	use ::nom_crate::InputTakeAtPosition;
+	use std::str::from_utf8;
+
+	let r = input.split_at_position(|c| c != b'u' && c != b'U' && c != b'l' && c != b'L');
+	match r {
+		Err(Err::Incomplete(_)) => Ok((&input[input.len()..], input)),
+		res => res,
+	}
+}
+
 named!(c_int<i64>,
 	map!(terminated!(alt_complete!(
-		map_opt!(preceded!(tag!("0x"),many1!(hexadecimal)),|v|c_int_radix(v,16)) |
-		map_opt!(preceded!(tag!("0b"),many1!(binary)),|v|c_int_radix(v,2)) |
-		map_opt!(preceded!(char!('0'),many1!(octal)),|v|c_int_radix(v,8)) |
-		map_opt!(many1!(decimal),|v|c_int_radix(v,10)) |
+		map_opt!(preceded!(tag!("0x"),many1!(complete!(hexadecimal))),|v|c_int_radix(v,16)) |
+		map_opt!(preceded!(tag!("0b"),many1!(complete!(binary))),|v|c_int_radix(v,2)) |
+		map_opt!(preceded!(char!('0'),many1!(complete!(octal))),|v|c_int_radix(v,8)) |
+		map_opt!(many1!(complete!(decimal)),|v|c_int_radix(v,10)) |
 		force_type!(IResult<_,_,u32>)
-	),is_a!("ulUL")),|i|i as i64)
+	),opt!(take_ul)),|i|i as i64)
 );
 
 // ==============================
@@ -205,15 +252,15 @@ named!(c_int<i64>,
 // ==============================
 
 named!(float_width<u8>,complete!(byte!(b'f' | b'l' | b'F' | b'L')));
-named!(float_exp<(Option<u8>,Vec<u8>)>,preceded!(byte!(b'e'|b'E'),pair!(opt!(byte!(b'-'|b'+')),many1!(decimal))));
+named!(float_exp<(Option<u8>,Vec<u8>)>,preceded!(byte!(b'e'|b'E'),pair!(opt!(byte!(b'-'|b'+')),many1!(complete!(decimal)))));
 
 named!(c_float<f64>,
 	map_opt!(alt!(
-		terminated!(recognize!(tuple!(many1!(decimal),byte!(b'.'),many0!(decimal))),opt!(float_width)) |
-		terminated!(recognize!(tuple!(many0!(decimal),byte!(b'.'),many1!(decimal))),opt!(float_width)) |
-		terminated!(recognize!(tuple!(many0!(decimal),opt!(byte!(b'.')),many1!(decimal),float_exp)),opt!(float_width)) |
-		terminated!(recognize!(tuple!(many1!(decimal),opt!(byte!(b'.')),many0!(decimal),float_exp)),opt!(float_width)) |
-		terminated!(recognize!(many1!(decimal)),float_width)
+		terminated!(recognize!(tuple!(many1!(complete!(decimal)),byte!(b'.'),many0!(complete!(decimal)))),opt!(float_width)) |
+		terminated!(recognize!(tuple!(many0!(complete!(decimal)),byte!(b'.'),many1!(complete!(decimal)))),opt!(float_width)) |
+		terminated!(recognize!(tuple!(many0!(complete!(decimal)),opt!(byte!(b'.')),many1!(complete!(decimal)),float_exp)),opt!(float_width)) |
+		terminated!(recognize!(tuple!(many1!(complete!(decimal)),opt!(byte!(b'.')),many0!(complete!(decimal)),float_exp)),opt!(float_width)) |
+		terminated!(recognize!(many1!(complete!(decimal))),float_width)
 	),|v|str::from_utf8(v).ok().and_then(|i|f64::from_str(i).ok()))
 );
 
@@ -223,10 +270,10 @@ named!(c_float<f64>,
 
 named!(one_literal<&[u8],EvalResult,::Error>,
 	fix_error!(::Error,alt_complete!(
-		map!(c_char,EvalResult::Char) |
-		map!(c_int,|i|EvalResult::Int(::std::num::Wrapping(i))) |
-		map!(c_float,EvalResult::Float) |
-		map!(c_string,EvalResult::Str)
+		map!(full!(c_char),EvalResult::Char) |
+		map!(full!(c_float),EvalResult::Float) |
+		map!(full!(c_int),|i|EvalResult::Int(::std::num::Wrapping(i))) |
+		map!(full!(c_string),EvalResult::Str)
 	))
 );
 

--- a/tests/clang.rs
+++ b/tests/clang.rs
@@ -68,7 +68,7 @@ fn test_definition(ident: Vec<u8>, tokens: &[Token], idents: &mut HashMap<Vec<u8
 		let mut fnidents;
 		let expr_tokens;
 		match fn_macro_declaration(&tokens) {
-			cexpr::nom::IResult::Done(rest,(_,args)) => {
+			Ok((rest,(_,args))) => {
 				fnidents=idents.clone();
 				expr_tokens=rest;
 				for arg in args {
@@ -87,11 +87,11 @@ fn test_definition(ident: Vec<u8>, tokens: &[Token], idents: &mut HashMap<Vec<u8
 		}
 		assert_full_parse(IdentifierParser::new(&fnidents).expr(&expr_tokens))
 	} else {
-		IdentifierParser::new(idents).macro_definition(&tokens).map(|(_,val)|val)
+		IdentifierParser::new(idents).macro_definition(&tokens).map(|(i, (_,val))|(i, val))
 	};
 
 	match result {
-		cexpr::nom::IResult::Done(_,val) => {
+		Ok((_,val)) => {
 			if val==test {
 				if let Some(_)=idents.insert(ident,val) {
 					panic!("Duplicate definition for testcase: {}",display_name);


### PR DESCRIPTION
Hello,

I'm currently testing the upgrade to nom 4 on various crates, to see if I forgot anything. Currently, I get this error after doing the following changes:

```
error[E0308]: if and else have incompatible types
  --> tests/clang.rs:67:15
   |
67 |       let result = if functional {
   |  __________________^
68 | |         let mut fnidents;
69 | |         let expr_tokens;
70 | |         match fn_macro_declaration(&tokens) {
...  |
90 | |         IdentifierParser::new(idents).macro_definition(&tokens).map(|(_,val)|val)
91 | |     };
   | |_____^ expected struct `cexpr::token::Token`, found u8
   |
   = note: expected type `std::result::Result<(&[cexpr::token::Token], cexpr::expr::EvalResult), cexpr::nom::Err<&[cexpr::token::Token], _>>`
              found type `std::result::Result<(&[u8], cexpr::expr::EvalResult), cexpr::nom::Err<&[cexpr::token::Token], _>>`

error: aborting due to previous error

error: Could not compile `cexpr`.
```

For a bit of context, here is the [upgrade doc for nom 4](https://github.com/Geal/nom/blob/master/doc/upgrading_to_nom_4.md).