### PR TITLE
Use a semver-compatible limit for clang-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ keywords = ["C","expression","parser"]
 nom = {version = "^4", features = ["verbose-errors"] }
 
 [dev-dependencies]
-clang-sys = ">= 0.13.0, <= 0.26.0"
+clang-sys = ">= 0.13.0, < 0.27.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cexpr"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Jethro Beekman <jethro@jbeekman.nl>"]
 license = "Apache-2.0/MIT"
 description = "A C expression parser and evaluator"


### PR DESCRIPTION
Use `clang-sys < 0.27.0` rather than `<= 0.26.0`, so that any
semver-compatible 0.26.x will be allowed.