### PR TITLE
Support capital integer literal prefixes (0X, 0B)

### DIFF
--- a/src/literal.rs
+++ b/src/literal.rs
@@ -225,7 +225,9 @@ fn take_ul(input: &[u8]) -> IResult<&[u8], &[u8]> {
 named!(c_int<i64>,
 	map!(terminated!(alt_complete!(
 		map_opt!(preceded!(tag!("0x"),many1!(complete!(hexadecimal))),|v|c_int_radix(v,16)) |
+		map_opt!(preceded!(tag!("0X"),many1!(complete!(hexadecimal))),|v|c_int_radix(v,16)) |
 		map_opt!(preceded!(tag!("0b"),many1!(complete!(binary))),|v|c_int_radix(v,2)) |
+		map_opt!(preceded!(tag!("0B"),many1!(complete!(binary))),|v|c_int_radix(v,2)) |
 		map_opt!(preceded!(char!('0'),many1!(complete!(octal))),|v|c_int_radix(v,8)) |
 		map_opt!(many1!(complete!(decimal)),|v|c_int_radix(v,10)) |
 		force_type!(IResult<_,_,u32>)

--- a/tests/input/int_unsigned.h
+++ b/tests/input/int_unsigned.h
@@ -3,6 +3,8 @@
 #define Int_1 0b1
 #define Int_2 0x2
 #define Int_3 3L
+#define Int_4 0X4
+#define Int_5 0B101
 #define Int_63 077
 #define Int_123 123
 #define Int_124 124u


### PR DESCRIPTION
From C/C++ standard standpoint capital 0X prefix is valid at least from C99 and capital 0B prefix is valid starting C++14. This PR adds basic tests and fixes both cases.