### PR TITLE
Upgrade to nom 5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["C","expression","parser"]
 travis-ci = { repository = "jethrogb/rust-cexpr" }
 
 [dependencies]
-nom = {version = "^4", features = ["verbose-errors"] }
+nom = "5"
 
 [dev-dependencies]
 clang-sys = ">= 0.13.0, < 0.29.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cexpr"
-version = "0.3.6"
+version = "0.4.0"
 edition = "2018"
 authors = ["Jethro Beekman <jethro@jbeekman.nl>"]
 license = "Apache-2.0/MIT"

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -43,10 +43,12 @@ pub struct IdentifierParser<'ident> {
 #[derive(Copy, Clone)]
 struct PRef<'a>(&'a IdentifierParser<'a>);
 
+/// A shorthand for the type of cexpr expression evaluation results.
 pub type CResult<'a, R> = IResult<&'a [Token], R, crate::Error<&'a [Token]>>;
 
 /// The result of parsing a literal or evaluating an expression.
 #[derive(Debug, Clone, PartialEq)]
+#[allow(missing_docs)]
 pub enum EvalResult {
     Int(Wrapping<i64>),
     Float(f64),

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -129,8 +129,7 @@ macro_rules! typed_token (
 #[allow(dead_code)]
 fn any_token(input: &[Token]) -> CResult<'_, &Token> {
     if input.is_empty() {
-        let res: CResult<'_, &Token> = Err(crate::nom::Err::Incomplete(Needed::Size(1)));
-        res
+        Err(crate::nom::Err::Incomplete(Needed::Size(1)))
     } else {
         Ok((&input[1..], &input[0]))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,16 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+//! A C expression parser and evaluator.
+//!
+//! This crate provides methods for parsing and evaluating simple C expressions. In general, the
+//! crate can handle most arithmetic expressions that would appear in macros or the definition of
+//! constants, as well as string and character constants.
+//!
+//! The main entry point for is [`token::parse`], which parses a byte string and returns its
+//! evaluated value.
 #![warn(rust_2018_idioms)]
+#![warn(missing_docs)]
 #![allow(deprecated)]
 
 pub mod nom {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,7 @@ where
 {
     match result.to_cexpr_result() {
         Ok((rem, output)) => {
-            if rem.len() == 0 {
+            if rem.is_empty() {
                 Ok((rem, output))
             } else {
                 Err(nom::Err::Error((rem, ErrorKind::Partial).into()))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,22 +8,17 @@
 #![warn(rust_2018_idioms)]
 #![allow(deprecated)]
 
-#[macro_use]
-extern crate nom as nom_crate;
-
 pub mod nom {
     //! nom's result types, re-exported.
-    pub use crate::nom_crate::{Err, ErrorKind, IResult, Needed};
+    pub use nom::{error::ErrorKind, Err, IResult, Needed};
 }
 pub mod expr;
 pub mod literal;
 pub mod token;
 
-use crate::nom::*;
-
-#[derive(Debug)]
 /// Parsing errors specific to C parsing
-pub enum Error {
+#[derive(Debug)]
+pub enum ErrorKind {
     /// Expected the specified token
     ExactToken(token::Kind, &'static [u8]),
     /// Expected one of the specified tokens
@@ -39,35 +34,98 @@ pub enum Error {
     InvalidLiteral,
     /// A full parse was requested, but data was left over after parsing finished.
     Partial,
+    /// An error occurred in an underlying nom parser.
+    Parser(nom::ErrorKind),
 }
 
-impl From<u32> for Error {
-    fn from(_: u32) -> Self {
-        Error::InvalidLiteral
+impl From<nom::ErrorKind> for ErrorKind {
+    fn from(k: nom::ErrorKind) -> Self {
+        ErrorKind::Parser(k)
     }
 }
 
-macro_rules! identity (
-    ($i:expr,$e:expr) => ($e);
-);
+impl From<u32> for ErrorKind {
+    fn from(_: u32) -> Self {
+        ErrorKind::InvalidLiteral
+    }
+}
+
+/// Parsing errors specific to C parsing.
+///
+/// This is a superset of `(I, nom::ErrorKind)` that includes the additional errors specified by
+/// [`ErrorKind`].
+#[derive(Debug)]
+pub struct Error<I> {
+    /// The remainder of the input stream at the time of the error.
+    pub input: I,
+    /// The error that occurred.
+    pub error: ErrorKind,
+}
+
+impl<I> From<(I, nom::ErrorKind)> for Error<I> {
+    fn from(e: (I, nom::ErrorKind)) -> Self {
+        Self::from((e.0, ErrorKind::from(e.1)))
+    }
+}
+
+impl<I> From<(I, ErrorKind)> for Error<I> {
+    fn from(e: (I, ErrorKind)) -> Self {
+        Self {
+            input: e.0,
+            error: e.1,
+        }
+    }
+}
+
+impl<I> ::nom::error::ParseError<I> for Error<I> {
+    fn from_error_kind(input: I, kind: nom::ErrorKind) -> Self {
+        Self {
+            input,
+            error: kind.into(),
+        }
+    }
+
+    fn append(_: I, _: nom::ErrorKind, other: Self) -> Self {
+        other
+    }
+}
+
+// in lieu of https://github.com/Geal/nom/issues/1010
+trait ToCexprResult<I, O> {
+    fn to_cexpr_result(self) -> nom::IResult<I, O, Error<I>>;
+}
+impl<I, O, E> ToCexprResult<I, O> for nom::IResult<I, O, E>
+where
+    Error<I>: From<E>,
+{
+    fn to_cexpr_result(self) -> nom::IResult<I, O, Error<I>> {
+        match self {
+            Ok(v) => Ok(v),
+            Err(nom::Err::Incomplete(n)) => Err(nom::Err::Incomplete(n)),
+            Err(nom::Err::Error(e)) => Err(nom::Err::Error(e.into())),
+            Err(nom::Err::Failure(e)) => Err(nom::Err::Failure(e.into())),
+        }
+    }
+}
 
 /// If the input result indicates a succesful parse, but there is data left,
 /// return an `Error::Partial` instead.
-pub fn assert_full_parse<I, O, E>(result: IResult<&[I], O, E>) -> IResult<&[I], O, crate::Error>
+pub fn assert_full_parse<'i, I: 'i, O, E>(
+    result: nom::IResult<&'i [I], O, E>,
+) -> nom::IResult<&'i [I], O, Error<&'i [I]>>
 where
-    Error: From<E>,
+    Error<&'i [I]>: From<E>,
 {
-    match fix_error!((), crate::Error, identity!(result)) {
+    match result.to_cexpr_result() {
         Ok((rem, output)) => {
             if rem.len() == 0 {
                 Ok((rem, output))
             } else {
-                Err(Err::Error(error_position!(
-                    rem,
-                    ErrorKind::Custom(crate::Error::Partial)
-                )))
+                Err(nom::Err::Error((rem, ErrorKind::Partial).into()))
             }
         }
-        r => r,
+        Err(nom::Err::Incomplete(n)) => Err(nom::Err::Incomplete(n)),
+        Err(nom::Err::Failure(e)) => Err(nom::Err::Failure(e)),
+        Err(nom::Err::Error(e)) => Err(nom::Err::Error(e)),
     }
 }

--- a/src/literal.rs
+++ b/src/literal.rs
@@ -39,9 +39,10 @@
 use std::char;
 use std::str::{self, FromStr};
 
-use crate::nom_crate::*;
+use nom::*;
 
 use crate::expr::EvalResult;
+use crate::ToCexprResult;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 /// Representation of a C character
@@ -80,56 +81,62 @@ impl Into<Vec<u8>> for CChar {
 }
 
 /// ensures the child parser consumes the whole input
-#[macro_export]
-macro_rules! full (
-	($i: expr, $submac:ident!( $($args:tt)* )) => (
-		{
-			use crate::nom_crate::lib::std::result::Result::*;
-			let res =  $submac!($i, $($args)*);
-			match res {
-				Ok((i, o)) => if i.len() == 0 {
-					Ok((i, o))
-				} else {
-					Err(crate::nom_crate::Err::Error(error_position!(i, crate::nom_crate::ErrorKind::Custom(42))))
-				},
-				r => r,
-			}
-		}
-	);
-	($i:expr, $f:ident) => (
-		full!($i, call!($f));
-	);
-);
-
-// ====================================================
-// ======== macros that shouldn't be necessary ========
-// ====================================================
-
-macro_rules! force_type (
-	($input:expr,IResult<$i:ty,$o:ty,$e:ty>) => (Err::<($i,$o),Err<$i,$e>>(crate::nom_crate::Err::Error(error_position!($input, ErrorKind::Fix))))
-);
+pub fn full<I: Clone, O, E: From<nom::error::ErrorKind>, F>(
+    f: F,
+) -> impl Fn(I) -> nom::IResult<I, O, (I, E)>
+where
+    I: nom::InputLength,
+    F: Fn(I) -> nom::IResult<I, O, (I, E)>,
+{
+    move |input| {
+        use nom::lib::std::result::Result::*;
+        let res = f(input);
+        match res {
+            Ok((i, o)) => {
+                if i.input_len() == 0 {
+                    Ok((i, o))
+                } else {
+                    Err(nom::Err::Error((i, nom::error::ErrorKind::Complete.into())))
+                }
+            }
+            r => r,
+        }
+    }
+}
 
 // =================================
 // ======== matching digits ========
 // =================================
 
-macro_rules! byte (
-	($i:expr, $($p: pat)|* ) => ({
-		match $i.split_first() {
-			$(Some((&c @ $p,rest)))|* => Ok::<(&[_],u8),crate::nom_crate::Err<&[_],u32>>((rest,c)),
-			Some(_) => Err(crate::nom_crate::Err::Error(error_position!($i, ErrorKind::OneOf))),
-			None => Err(crate::nom_crate::Err::Incomplete(Needed::Size(1))),
-		}
-	})
-);
+macro_rules! byte {
+	($($p: pat)|* ) => {{
+        fn parser(i: &[u8]) -> crate::nom::IResult<&[u8], u8> {
+            match i.split_first() {
+                $(Some((&c @ $p,rest)))|* => Ok((rest,c)),
+                Some(_) => Err(nom::Err::Error((i, nom::error::ErrorKind::OneOf))),
+                None => Err(nom::Err::Incomplete(Needed::Size(1))),
+            }
+        }
 
-named!(binary<u8>, byte!(b'0'..=b'1'));
-named!(octal<u8>, byte!(b'0'..=b'7'));
-named!(decimal<u8>, byte!(b'0'..=b'9'));
-named!(
-    hexadecimal<u8>,
-    byte!(b'0' ..= b'9' | b'a' ..= b'f' | b'A' ..= b'F')
-);
+        parser
+	}}
+}
+
+fn binary(i: &[u8]) -> nom::IResult<&[u8], u8> {
+    byte!(b'0'..=b'1')(i)
+}
+
+fn octal(i: &[u8]) -> nom::IResult<&[u8], u8> {
+    byte!(b'0'..=b'7')(i)
+}
+
+fn decimal(i: &[u8]) -> nom::IResult<&[u8], u8> {
+    byte!(b'0'..=b'9')(i)
+}
+
+fn hexadecimal(i: &[u8]) -> nom::IResult<&[u8], u8> {
+    byte!(b'0' ..= b'9' | b'a' ..= b'f' | b'A' ..= b'F')(i)
+}
 
 // ========================================
 // ======== characters and strings ========
@@ -166,62 +173,77 @@ fn c_unicode_escape(n: Vec<u8>) -> Option<CChar> {
         .map(CChar::Char)
 }
 
-named!(
-    escaped_char<CChar>,
-    preceded!(
-        complete!(char!('\\')),
-        alt_complete!(
-            map!(one_of!(r#"'"?\"#), CChar::Char)
-                | map!(one_of!("abfnrtv"), escape2char)
-                | map_opt!(many_m_n!(1, 3, octal), |v| c_raw_escape(v, 8))
-                | map_opt!(
-                    preceded!(char!('x'), many1!(hexadecimal)),
-                    |v| c_raw_escape(v, 16)
-                )
-                | map_opt!(
-                    preceded!(char!('u'), many_m_n!(4, 4, hexadecimal)),
-                    c_unicode_escape
-                )
-                | map_opt!(
-                    preceded!(char!('U'), many_m_n!(8, 8, hexadecimal)),
-                    c_unicode_escape
-                )
-        )
-    )
-);
-
-named!(
-    c_width_prefix,
-    alt!(tag!("u8") | tag!("u") | tag!("U") | tag!("L"))
-);
-
-named!(
-    c_char<CChar>,
-    delimited!(
-        terminated!(opt!(c_width_prefix), char!('\'')),
-        alt!(escaped_char | map!(byte!(0 ..= 91 /* \=92 */ | 93 ..= 255), CChar::from)),
-        char!('\'')
-    )
-);
-
-named!(
-    c_string<Vec<u8>>,
-    delimited!(
-        alt!(preceded!(c_width_prefix, char!('"')) | char!('"')),
-        fold_many0!(
-            alt!(
-                map!(escaped_char, |c: CChar| c.into())
-                    | map!(is_not!([b'\\', b'"']), |c: &[u8]| c.into())
+fn escaped_char(i: &[u8]) -> nom::IResult<&[u8], CChar> {
+    use nom::branch::alt;
+    use nom::character::complete::{char, one_of};
+    use nom::combinator::{map, map_opt};
+    use nom::multi::{many1, many_m_n};
+    use nom::sequence::preceded;
+    preceded(
+        char('\\'),
+        alt((
+            map(one_of(r#"'"?\"#), CChar::Char),
+            map(one_of("abfnrtv"), escape2char),
+            map_opt(many_m_n(1, 3, octal), |v| c_raw_escape(v, 8)),
+            map_opt(preceded(char('x'), many1(hexadecimal)), |v| {
+                c_raw_escape(v, 16)
+            }),
+            map_opt(
+                preceded(char('u'), many_m_n(4, 4, hexadecimal)),
+                c_unicode_escape,
             ),
+            map_opt(
+                preceded(char('U'), many_m_n(8, 8, hexadecimal)),
+                c_unicode_escape,
+            ),
+        )),
+    )(i)
+}
+
+fn c_width_prefix(i: &[u8]) -> nom::IResult<&[u8], &[u8]> {
+    use nom::branch::alt;
+    use nom::bytes::complete::tag;
+    alt((tag("u8"), tag("u"), tag("U"), tag("L")))(i)
+}
+
+fn c_char(i: &[u8]) -> nom::IResult<&[u8], CChar> {
+    use nom::branch::alt;
+    use nom::character::complete::char;
+    use nom::combinator::{map, opt};
+    use nom::sequence::{delimited, terminated};
+    delimited(
+        terminated(opt(c_width_prefix), char('\'')),
+        alt((
+            escaped_char,
+            map(byte!(0 ..= 91 /* \=92 */ | 93 ..= 255), CChar::from),
+        )),
+        char('\''),
+    )(i)
+}
+
+fn c_string(i: &[u8]) -> nom::IResult<&[u8], Vec<u8>> {
+    use nom::branch::alt;
+    use nom::bytes::complete::is_not;
+    use nom::character::complete::char;
+    use nom::combinator::map;
+    use nom::multi::fold_many0;
+    use nom::sequence::{delimited, preceded};
+    delimited(
+        alt((preceded(c_width_prefix, char('"')), char('"'))),
+        fold_many0(
+            alt((
+                map(escaped_char, |c: CChar| c.into()),
+                map(is_not([b'\\', b'"']), |c: &[u8]| c.into()),
+            )),
             Vec::new(),
             |mut v: Vec<u8>, res: Vec<u8>| {
                 v.extend_from_slice(&res);
                 v
-            }
+            },
         ),
-        char!('"')
-    )
-);
+        char('"'),
+    )(i)
+}
 
 // ================================
 // ======== parse integers ========
@@ -241,100 +263,126 @@ fn take_ul(input: &[u8]) -> IResult<&[u8], &[u8]> {
     }
 }
 
-named!(
-    c_int<i64>,
-    map!(
-        terminated!(
-            alt_complete!(
-                map_opt!(preceded!(tag!("0x"), many1!(complete!(hexadecimal))), |v| {
+fn c_int(i: &[u8]) -> nom::IResult<&[u8], i64> {
+    use nom::branch::alt;
+    use nom::bytes::complete::tag;
+    use nom::character::complete::char;
+    use nom::combinator::{complete, map, map_opt, opt};
+    use nom::multi::many1;
+    use nom::sequence::{preceded, terminated};
+    map(
+        terminated(
+            alt((
+                map_opt(preceded(tag("0x"), many1(complete(hexadecimal))), |v| {
                     c_int_radix(v, 16)
-                }) | map_opt!(preceded!(tag!("0X"), many1!(complete!(hexadecimal))), |v| {
+                }),
+                map_opt(preceded(tag("0X"), many1(complete(hexadecimal))), |v| {
                     c_int_radix(v, 16)
-                }) | map_opt!(preceded!(tag!("0b"), many1!(complete!(binary))), |v| {
+                }),
+                map_opt(preceded(tag("0b"), many1(complete(binary))), |v| {
                     c_int_radix(v, 2)
-                }) | map_opt!(preceded!(tag!("0B"), many1!(complete!(binary))), |v| {
+                }),
+                map_opt(preceded(tag("0B"), many1(complete(binary))), |v| {
                     c_int_radix(v, 2)
-                }) | map_opt!(preceded!(char!('0'), many1!(complete!(octal))), |v| {
+                }),
+                map_opt(preceded(char('0'), many1(complete(octal))), |v| {
                     c_int_radix(v, 8)
-                }) | map_opt!(many1!(complete!(decimal)), |v| c_int_radix(v, 10))
-                    | force_type!(IResult<_, _, u32>)
-            ),
-            opt!(take_ul)
+                }),
+                map_opt(many1(complete(decimal)), |v| c_int_radix(v, 10)),
+                |input| Err(crate::nom::Err::Error((input, crate::nom::ErrorKind::Fix))),
+            )),
+            opt(take_ul),
         ),
-        |i| i as i64
-    )
-);
+        |i| i as i64,
+    )(i)
+}
 
 // ==============================
 // ======== parse floats ========
 // ==============================
 
-named!(float_width<u8>, complete!(byte!(b'f' | b'l' | b'F' | b'L')));
-named!(
-    float_exp<(Option<u8>, Vec<u8>)>,
-    preceded!(
-        byte!(b'e' | b'E'),
-        pair!(opt!(byte!(b'-' | b'+')), many1!(complete!(decimal)))
-    )
-);
+fn float_width(i: &[u8]) -> nom::IResult<&[u8], u8> {
+    nom::combinator::complete(byte!(b'f' | b'l' | b'F' | b'L'))(i)
+}
 
-named!(
-    c_float<f64>,
-    map_opt!(
-        alt!(
-            terminated!(
-                recognize!(tuple!(
-                    many1!(complete!(decimal)),
+fn float_exp(i: &[u8]) -> nom::IResult<&[u8], (Option<u8>, Vec<u8>)> {
+    use nom::combinator::{complete, opt};
+    use nom::multi::many1;
+    use nom::sequence::{pair, preceded};
+    preceded(
+        byte!(b'e' | b'E'),
+        pair(opt(byte!(b'-' | b'+')), many1(complete(decimal))),
+    )(i)
+}
+
+fn c_float(i: &[u8]) -> nom::IResult<&[u8], f64> {
+    use nom::branch::alt;
+    use nom::combinator::{complete, map_opt, opt, recognize};
+    use nom::multi::{many0, many1};
+    use nom::sequence::{terminated, tuple};
+    map_opt(
+        alt((
+            terminated(
+                recognize(tuple((
+                    many1(complete(decimal)),
                     byte!(b'.'),
-                    many0!(complete!(decimal))
-                )),
-                opt!(float_width)
-            ) | terminated!(
-                recognize!(tuple!(
-                    many0!(complete!(decimal)),
+                    many0(complete(decimal)),
+                ))),
+                opt(float_width),
+            ),
+            terminated(
+                recognize(tuple((
+                    many0(complete(decimal)),
                     byte!(b'.'),
-                    many1!(complete!(decimal))
-                )),
-                opt!(float_width)
-            ) | terminated!(
-                recognize!(tuple!(
-                    many0!(complete!(decimal)),
-                    opt!(byte!(b'.')),
-                    many1!(complete!(decimal)),
-                    float_exp
-                )),
-                opt!(float_width)
-            ) | terminated!(
-                recognize!(tuple!(
-                    many1!(complete!(decimal)),
-                    opt!(byte!(b'.')),
-                    many0!(complete!(decimal)),
-                    float_exp
-                )),
-                opt!(float_width)
-            ) | terminated!(recognize!(many1!(complete!(decimal))), float_width)
-        ),
-        |v| str::from_utf8(v).ok().and_then(|i| f64::from_str(i).ok())
-    )
-);
+                    many1(complete(decimal)),
+                ))),
+                opt(float_width),
+            ),
+            terminated(
+                recognize(tuple((
+                    many0(complete(decimal)),
+                    opt(byte!(b'.')),
+                    many1(complete(decimal)),
+                    float_exp,
+                ))),
+                opt(float_width),
+            ),
+            terminated(
+                recognize(tuple((
+                    many1(complete(decimal)),
+                    opt(byte!(b'.')),
+                    many0(complete(decimal)),
+                    float_exp,
+                ))),
+                opt(float_width),
+            ),
+            terminated(recognize(many1(complete(decimal))), float_width),
+        )),
+        |v| str::from_utf8(v).ok().and_then(|i| f64::from_str(i).ok()),
+    )(i)
+}
 
 // ================================
 // ======== main interface ========
 // ================================
 
-named!(one_literal<&[u8],EvalResult,crate::Error>,
-	fix_error!(crate::Error,alt_complete!(
-		map!(full!(c_char),EvalResult::Char) |
-		map!(full!(c_int),|i|EvalResult::Int(::std::num::Wrapping(i))) |
-		map!(full!(c_float),EvalResult::Float) |
-		map!(full!(c_string),EvalResult::Str)
-	))
-);
+fn one_literal(input: &[u8]) -> nom::IResult<&[u8], EvalResult, crate::Error<&[u8]>> {
+    use nom::branch::alt;
+    use nom::combinator::map;
+
+    alt((
+        map(full(c_char), EvalResult::Char),
+        map(full(c_int), |i| EvalResult::Int(::std::num::Wrapping(i))),
+        map(full(c_float), EvalResult::Float),
+        map(full(c_string), EvalResult::Str),
+    ))(input)
+    .to_cexpr_result()
+}
 
 /// Parse a C literal.
 ///
 /// The input must contain exactly the representation of a single literal
 /// token, and in particular no whitespace or sign prefixes.
-pub fn parse(input: &[u8]) -> IResult<&[u8], EvalResult, crate::Error> {
+pub fn parse(input: &[u8]) -> IResult<&[u8], EvalResult, crate::Error<&[u8]>> {
     crate::assert_full_parse(one_literal(input))
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -31,7 +31,7 @@ pub struct Token {
 impl<'a> From<(Kind, &'a [u8])> for Token {
     fn from((kind, value): (Kind, &'a [u8])) -> Token {
         Token {
-            kind: kind,
+            kind,
             raw: value.to_owned().into_boxed_slice(),
         }
     }

--- a/src/token.rs
+++ b/src/token.rs
@@ -10,6 +10,7 @@
 //! This is designed to map onto a libclang CXToken.
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[allow(missing_docs)]
 pub enum Kind {
     Punctuation,
     Keyword,
@@ -18,9 +19,12 @@ pub enum Kind {
     Comment,
 }
 
+/// A single token in a C expression.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Token {
+    /// The type of this token.
     pub kind: Kind,
+    /// The bytes that make up the token.
     pub raw: Box<[u8]>,
 }
 


### PR DESCRIPTION
This patchset builds on #21, and bumps the dependency on `nom` to version 5. The change is a fairly major one, since `nom` moved away from macro-based parsers to combinators based on function callbacks.

Fixes #19 

---

**Old obsolete text:**

The current state of affairs is that this _almost_ compiles. The biggest remaining issue is how to pass the methods of `expr::PRef` in the new function-passing style. The errors should pretty quickly make it obvious what's going on. I'm honestly not sure what the right way to go about this is. The methods that call them may need to be re-written in the sort of "linear" style that `nom 5` favors. [`nom-methods`](https://docs.rs/nom-methods/) may provide some inspiration here. The new `&mut self` style also makes it awkward to have a combinator that may call multiple different methods on `self`.  It may be that we want to return to the old "consume self return Self" strategy to get around this.

I don't know that I'll have the time to finish this PR up any time soon, so @jethrogb if you want to pick this up and run with it, feel free!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jethrogb/rust-cexpr/22)
<!-- Reviewable:end -->
