### PR TITLE
Only use needed features from nom

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["C","expression","parser"]
 travis-ci = { repository = "jethrogb/rust-cexpr" }
 
 [dependencies]
-nom = "5"
+nom = { version = "5", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 clang-sys = ">= 0.13.0, < 0.29.0"


### PR DESCRIPTION
Most importantly stop depending on the large lexical-core dependency.

This reduces clean build by about 3 seconds