### PR TITLE
Update to nom 6.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["C","expression","parser"]
 travis-ci = { repository = "jethrogb/rust-cexpr" }
 
 [dependencies]
-nom = { version = "5", default-features = false, features = ["std"] }
+nom = { version = "6", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 clang-sys = ">= 0.13.0, < 0.29.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 
 pub mod nom {
     //! nom's result types, re-exported.
-    pub use nom::{error::ErrorKind, Err, IResult, Needed};
+    pub use nom::{error::ErrorKind, error::Error, Err, IResult, Needed};
 }
 pub mod expr;
 pub mod literal;
@@ -82,6 +82,15 @@ impl<I> From<(I, ErrorKind)> for Error<I> {
         Self {
             input: e.0,
             error: e.1,
+        }
+    }
+}
+
+impl<I> From<::nom::error::Error<I>> for Error<I> {
+    fn from(e: ::nom::error::Error<I>) -> Self {
+        Self {
+            input: e.input,
+            error: e.code.into(),
         }
     }
 }


### PR DESCRIPTION
This is an upgrade to nom 6.x. It was tested via `cargo test`. @jethrogb Could you please review? Could you please also consider adding @emilio as maintainer (see #23)? Thanks.

Old obsolete message:
> This is an attempt at upgrading to nom 6.x. There is still an issue in `typed_token` about the expected lifetime of the input. @jonhoo, since you did the port to nom 5.x, you may have some insight on how to fix this.
@jethrogb, any feedback is appreciated. Thanks.

Bug: #26